### PR TITLE
make qdb behavior a little more intuitive

### DIFF
--- a/iicmd.sh
+++ b/iicmd.sh
@@ -23,7 +23,8 @@ commands=(
 
 qdb() {
     file="$qdbdir/$(date +%s).qdb"
-    sed -ne '/'"$1"'/,$p' -e '/'"$2"'/q' "$ircdir/$netw/$chan/out" > "$file"
+    head -n-1 "$ircdir/$netw/$chan/out"\
+        | tac | sed "/$1/q" | tac | sed "/$2/q" > "$file"
     echo "Added the $(wc -l $file | cut -f1 -d' ') messages starting with:"
     head -1 $file
 }


### PR DESCRIPTION
```
`qdb a b`
```

will now match the from the _last_ line matching a to the _next_ line matching b, minimizing the number of lines the match-regex needs to disambiguate.
